### PR TITLE
Use C project and bump version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,6 @@
-cmake_minimum_required (VERSION 2.8.11)
+cmake_minimum_required(VERSION 3.12)
 
-#project(libmsym C) # unfortunately GenerateExportHeader doesn't support C projects, which sort of makes this project reqire c++ =/
-
-project(libmsym)
+project(libmsym C)
 
 option(MSYM_BUILD_EXAMPLES "Build example executables" OFF)
 option(MSYM_BUILD_PYTHON "Build python binding" OFF)


### PR DESCRIPTION
CMake version `3.12` has introduced `generate_export_header()` for C projects ([see documentation](https://cmake.org/cmake/help/latest/module/GenerateExportHeader.html)). 🙂

The version bump also fixes https://github.com/mcodev31/libmsym/issues/18.