### PR TITLE
enhanced the python binding by adding some missing class and better string representation

### DIFF
--- a/bindings/python/libmsym/libmsym.py
+++ b/bindings/python/libmsym/libmsym.py
@@ -133,6 +133,7 @@ class EquivalenceSets(Structure):
         addresses = [addressof(ele) for ele in elements]
         self.elements = []
         for ele in self._elements[0:self.length]:
+            
             pyEle = elements[addresses.index(addressof(ele.contents))]
             pyEle.equiv = self
             self.elements.append(pyEle)
@@ -198,8 +199,8 @@ class Subgroup(Structure):
     def _update_symmetry_operations(self, symmetry_operations):
         addresses = [addressof(sop) for sop in symmetry_operations]
         self.symmetry_operations = [symmetry_operations[addresses.index(addressof(sop.contents))] for sop in self._sops[0:self.n]]
-        index = addresses.index(addressof(self._primary.contents))
-        if index != -1:
+        if self._primary:
+            index = addresses.index(addressof(self._primary.contents))
             self.primary_operations = symmetry_operations[index]
 
 Subgroup._fields_ = [("type", c_int),
@@ -580,7 +581,7 @@ class Context(object):
     def __init__(self, elements=[], basis_functions=[], point_group=""):
         if(_lib is None):
             raise Error("Shared library not loaded")
-            
+        
         self._elements = []
         self._basis_functions = []
         self._salc_wf = None
@@ -805,7 +806,7 @@ class Context(object):
     def _update_basis_function_element(self):
         for bf in self.basis_functions:
             element = bf.element
-            bf.element = self.elements[self.elements.index(element)]
+            bf.element = self.elements[element.index-1]
 
     def find_misc(self, to_print = True):
         if not self._ctx:

--- a/src/elements.c
+++ b/src/elements.c
@@ -15,6 +15,11 @@
 
 #include "debug.h"
 
+#define EXTRA_NUM 256
+
+static char extra_elements[EXTRA_NUM][32];
+static int n_extra = 0;
+
 const struct _periodic_table {
     int n;
     char *name;
@@ -204,11 +209,32 @@ msym_error_t complementElementData(msym_element_t *element){
         }
         
         if(fi == fil){
+            for (fi =0; fi < n_extra; fi++) {
+                if (0 == strcmp(element->name, extra_elements[fi])) {
+                    int n = fi + 1000;
+                    if(element->m <= 0.0) element->m = (double) n;
+                    if(element->n <= 0) element->n = n;
+                }
+            }
+            if (fi == n_extra) {
+                if (n_extra == EXTRA_NUM) {
+                    msymSetErrorDetails("Cannot set extra elements more than %d", EXTRA_NUM);
+                    ret = MSYM_INVALID_ELEMENTS;
+                    goto err;
+                }
+                strncpy(extra_elements[n_extra], element->name, 32);
+                int n = n_extra + 1000;
+                if(element->m <= 0.0) element->m = (double) n;
+                if(element->n <= 0) element->n = n;
+                n_extra++;
+            }
+            /*
             char buf[sizeof(element->name)];
             snprintf(buf, sizeof(element->name), "%s",element->name); //in case someone forgets to null terminate
             msymSetErrorDetails("Unknown element with name %s",buf);
             ret = MSYM_INVALID_ELEMENTS;
             goto err;
+            */
         }
     } else if(element->m > 0.0 && (strl <= 0 || element->n <= 0)){
         int fim = 0, fil = sizeof(periodic_table)/sizeof(periodic_table[0]);

--- a/src/elements.c
+++ b/src/elements.c
@@ -15,9 +15,9 @@
 
 #include "debug.h"
 
-#define EXTRA_NUM 256
+#define EXTRA_NUM 1024
 
-static char extra_elements[EXTRA_NUM][32];
+static char extra_elements[EXTRA_NUM][4];
 static int n_extra = 0;
 
 const struct _periodic_table {
@@ -210,7 +210,7 @@ msym_error_t complementElementData(msym_element_t *element){
         
         if(fi == fil){
             for (fi =0; fi < n_extra; fi++) {
-                if (0 == strcmp(element->name, extra_elements[fi])) {
+                if (0 == strncmp(element->name, extra_elements[fi], sizeof(extra_elements[fi]))) {
                     int n = fi + 1000;
                     if(element->m <= 0.0) element->m = (double) n;
                     if(element->n <= 0) element->n = n;
@@ -222,7 +222,7 @@ msym_error_t complementElementData(msym_element_t *element){
                     ret = MSYM_INVALID_ELEMENTS;
                     goto err;
                 }
-                strncpy(extra_elements[n_extra], element->name, 32);
+                strncpy(extra_elements[n_extra], element->name, sizeof(extra_elements[n_extra]));
                 int n = n_extra + 1000;
                 if(element->m <= 0.0) element->m = (double) n;
                 if(element->n <= 0) element->n = n;


### PR DESCRIPTION

Dear all,

I have made some modifications to the libmsym Python binding by adding the missing class, such as **subgroup**, and providing a more enhanced string representation.

In the `element.c` file, I have adjusted the code to allow for unknown element names, with a maximum length of 1024 extra unknown elements. This means that atomic elements like "MX" are now permitted in libmsym.

Your sincerely,
_Kylin_